### PR TITLE
Update to zip_next 1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ keywords = ["parser", "android", "timezone"]
 include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [dev-dependencies]
-zip = "0.6.4"
+zip_next = "1.0.1"

--- a/src/tzdata.rs
+++ b/src/tzdata.rs
@@ -155,7 +155,7 @@ mod test {
     #[test]
     fn parse() {
         let mut archive = File::open("tests/resources/tzdata.zip").unwrap();
-        let mut zip = zip::ZipArchive::new(&mut archive).unwrap();
+        let mut zip = zip_next::ZipArchive::new(&mut archive).unwrap();
         let mut file = zip.by_index(0).unwrap();
         let mut data = Vec::new();
         file.read_to_end(&mut data).unwrap();


### PR DESCRIPTION
The `zip` crate hasn't been updated in almost a year, and has a number of bugs that can cause panics when trying to process an invalid zip file. `zip_next` is an actively-maintained fork and is fuzzed to ensure no panics.