### PR TITLE
test(deps): Update `zip`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ keywords = ["parser", "android", "timezone"]
 include = ["src/**/*", "LICENSE-*", "README.md"]
 
 [dev-dependencies]
-zip = "0.6.4"
+zip = "2"


### PR DESCRIPTION
Updates `zip` from 0.6.4 (ancient and no longer supported) to 2.x.